### PR TITLE
feat: add bg color property on PET model

### DIFF
--- a/app/models/pet.py
+++ b/app/models/pet.py
@@ -37,6 +37,7 @@ class Pet(Base):
     documents: Mapped[List["Document"]] = relationship("Document", back_populates="pet", cascade="all, delete-orphan")
     events: Mapped[List["Event"]] = relationship("Event", back_populates="pet", cascade="all, delete-orphan")
     avatar: Mapped[str] = mapped_column(String, nullable=True)
+    bg_color: Mapped[str] = mapped_column(String, nullable=True)
 
 
 class MedicalInfo(Base):

--- a/app/schemas/pet.py
+++ b/app/schemas/pet.py
@@ -16,6 +16,7 @@ class PetBase(BaseModel):
     weight: float
     chip_number: Optional[int] = None
     chronic_illnesses: Optional[bool] = False
+    bg_color: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
Este es un PR solicitado por Frontend para guardar en BD el color de fondo de la mascota.
Es importante que se apruebe antes del PR de **frontend** con el issue #fix/random-bgcolor-in-petcard #91
